### PR TITLE
mongobleed: Add tcpdump pcap sidecar + normalize exploit targets with reachability checks (keep scan flow)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   mongodb-vulnerable:
     image: mongo:8.2.2
@@ -15,7 +13,22 @@ services:
       - mongodb_data:/data/db
     command: ["mongod", "--networkMessageCompressors", "zlib", "--bind_ip_all"]
     restart: unless-stopped
+  tcpdump:
+    image: nicolaka/netshoot
+    container_name: mongobleed-tcpdump
+    network_mode: "service:mongodb-vulnerable"
+    cap_add:
+      - NET_ADMIN
+    command: >
+      sh -c 'mkdir -p /pcaps && idx=0;
+      while true; do
+        tcpdump -n -q -i any port 27017 -U -w "/pcaps/mongo_$$(printf ''%06d'' $$idx).pcap" &&
+        idx=$$((idx+1));
+      done'
+    volumes:
+      - ./pcaps:/pcaps
+    depends_on:
+      - mongodb-vulnerable
 
 volumes:
   mongodb_data:
-


### PR DESCRIPTION
- Docker Compose: add tcpdump sidecar that adds pcaps packetsfile into ./pcaps
- Exploit script: normalize targets (host:port, IPv6), reuse normalized host/port for logging and probes, and fail fast with a reachability check plus clear error messaging.
- Preserves existing scan flow while improving target handling and visibility.